### PR TITLE
feat: 添加自定义保存目录选择功能

### DIFF
--- a/screenpen/screenpen.py
+++ b/screenpen/screenpen.py
@@ -51,6 +51,8 @@ if pyqt_version == 5:
     from PyQt5.QtWidgets import QMainWindow, QApplication, QDesktopWidget
     from PyQt5.QtCore import QPoint, Qt, QSize
     from PyQt5.QtWidgets import QToolBar, QAction, QDialog, QToolButton, QMenu, QColorDialog
+    # 文件选择
+    from PyQt5.QtWidgets import QFileDialog
     from PyQt5.QtGui import (
         QIcon, QScreen, QPalette, QColor, QCursor,
         QSyntaxHighlighter, QPixmap, QKeySequence
@@ -728,12 +730,15 @@ setattr(self, 'drawChart', drawChart)
         for tb in self.toolBars:
             tb.show()
         return img
-
+    def saveLocation(self):
+        fname = QFileDialog.getExistingDirectory(self, '选择保存目录', '/home')
+        return fname
     def saveDrawing(self):
         def _saveDrawing(n=0):
             filename = f'{datetime.now().strftime("%Y%m%d_%H%M%S")}.png'
-            print(f'Saving {filename}')
-            self.captureScreen().save(f'{filename}')
+            location = self.saveLocation()+"/"
+            print(f'Saving {location}{filename}')
+            self.captureScreen().save(f'{location}{filename}')
         return _saveDrawing
 
     def colorPicker(self):


### PR DESCRIPTION
### 改动说明
1. 引入 QFileDialog 模块
2. 新增 saveLocation 方法，弹出文件夹选择对话框，默认打开 /home
3. 修改 _saveDrawing 逻辑，先选择目录，再将截图保存至所选目录

### 测试点
- 点击保存截图，唤起目录选择窗口
- 选定文件夹后，截图保存到目标路径，文件名仍使用时间戳命名
